### PR TITLE
Updates dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     directory: "/src"
     schedule:
       interval: "weekly"
+      day: "sunday"
+    allow:
+      - dependency-type: direct
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "Dependabot package update"
     open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
- Now ignoring patch nuget package updates
- Update checks are now done explicitly on Sunday
- Added check for github-actions