### PR TITLE
Fix IComparable null contract, GetBytes immutability, TryParse contro…

### DIFF
--- a/src/NetDuid.Tests/Duid.FactoryTests.cs
+++ b/src/NetDuid.Tests/Duid.FactoryTests.cs
@@ -72,11 +72,30 @@ namespace NetDuid.Tests
             AddTestCase(string.Empty);
             AddTestCase("potato");
 
+            // whitespace-only strings — IsNullOrEmpty returns false, Trim() produces "", no regex match
+            AddTestCase("   ");
+            AddTestCase("\t");
+            AddTestCase(" \t \r\n");
+
             // invalid lengths
             foreach (var byteLength in new[] { 1, 2, 131, 200 })
             {
                 AddTestCase(StaticTestData.GenerateBytes(byteLength).BytesAsString());
             }
+
+            // mixed delimiters — delimited regex backreference \k<separator> requires a consistent delimiter
+            AddTestCase("AB:CD-EF");
+            AddTestCase("AB-CD:EF");
+            AddTestCase("AB CD:EF");
+
+            // structural problems
+            AddTestCase(":AB:CD:EF");
+            AddTestCase("AB:CD:EF:");
+            AddTestCase("AB::CD:EF");
+
+            // invalid hex characters
+            AddTestCase("GG:HH:II");
+            AddTestCase("GGHHII");
 
             return theoryData;
 
@@ -150,6 +169,64 @@ namespace NetDuid.Tests
             // Act
             // Assert
             Assert.Throws<ArgumentException>(() => Duid.Parse(inputString, null));
+        }
+
+        #endregion
+
+        #region Parse — whitespace edge cases
+
+        [Fact]
+        public void Parse_WhitespaceOnly_ThrowsArgumentException_WithParseFailMessage_Test()
+        {
+            // Arrange
+            // (whitespace-only takes a different code path than null/empty — IsNullOrEmpty returns false,
+            // Trim() produces "", no regex match, so the "could not parse" message is thrown, not "cannot be null or empty")
+
+            // Act
+            var exception = Assert.Throws<ArgumentException>(() => Duid.Parse("   "));
+
+            // Assert
+            Assert.Contains("could not parse", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static TheoryData<byte[], string> Parse_WithSurroundingWhitespace_Success_Test_TestCases()
+        {
+            var theoryData = new TheoryData<byte[], string>();
+            var bytes = StaticTestData.GenerateBytes(3, 100);
+
+            theoryData.Add(bytes, " " + bytes.BytesAsString(":") + " ");
+            theoryData.Add(bytes, "\t" + bytes.BytesAsString("-") + "\t");
+            theoryData.Add(bytes, bytes.BytesAsString(string.Empty) + "\n");
+            theoryData.Add(bytes, "  " + bytes.BytesAsString(" ") + "  ");
+            theoryData.Add(bytes, "   " + bytes.BytesAsString(":"));
+            theoryData.Add(bytes, bytes.BytesAsString("-") + "   ");
+
+            return theoryData;
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_WithSurroundingWhitespace_Success_Test_TestCases))]
+        public void TryParse_WithSurroundingWhitespace_Success_Test(byte[] expectedBytes, string inputString)
+        {
+            // Arrange
+            // Act
+            var success = Duid.TryParse(inputString, out var duid);
+
+            // Assert
+            Assert.True(success, "parse failed");
+            Assert.Equal(expectedBytes, duid.GetBytes());
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_WithSurroundingWhitespace_Success_Test_TestCases))]
+        public void Parse_WithSurroundingWhitespace_Success_Test(byte[] expectedBytes, string inputString)
+        {
+            // Arrange
+            // Act
+            var duid = Duid.Parse(inputString);
+
+            // Assert
+            Assert.Equal(expectedBytes, duid.GetBytes());
         }
 
         #endregion

--- a/src/NetDuid.Tests/Duid.IComparableTests.cs
+++ b/src/NetDuid.Tests/Duid.IComparableTests.cs
@@ -14,7 +14,7 @@ namespace NetDuid.Tests
             var referenceDuid = new Duid(new byte[] { 0x00, 0x00, 0xff });
 
             AddTestCase(0, referenceDuid, referenceDuid); // by reference
-            AddTestCase(-1, referenceDuid, null); // null case
+            AddTestCase(1, referenceDuid, null); // null case — non-null is greater than null per IComparable contract
 
             // equality
             AddCommutativeTestCases(0, new byte[] { 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00, 0x00 });

--- a/src/NetDuid.Tests/Duid.IFormattableTests.cs
+++ b/src/NetDuid.Tests/Duid.IFormattableTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace NetDuid.Tests
 {
@@ -79,6 +80,53 @@ namespace NetDuid.Tests
 
             // Assert
             Assert.Equal(expectedString, result);
+        }
+
+        #endregion
+
+        #region ToString(string, IFormatProvider) — invalid format
+
+        public static TheoryData<string> ToString_InvalidFormat_ThrowsFormatException_Test_TestCases()
+        {
+            var theoryData = new TheoryData<string>();
+
+            // format string too long (> 2 characters)
+            theoryData.Add("ABC");
+            theoryData.Add("U:X");
+            theoryData.Add("UU:");
+
+            // single character — not in the valid set (U, u, L, l, :, -)
+            theoryData.Add("X");
+            theoryData.Add("A");
+            theoryData.Add("1");
+            theoryData.Add("?");
+
+            // two characters — first character not U, u, L, or l
+            theoryData.Add("X:");
+            theoryData.Add("1-");
+            theoryData.Add("AU");
+
+            // two characters — second character not ':' or '-'
+            // note: space is a valid parse delimiter but not a valid format delimiter
+            theoryData.Add("UX");
+            theoryData.Add("LA");
+            theoryData.Add("U1");
+            theoryData.Add("L ");
+            theoryData.Add("U.");
+
+            return theoryData;
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_InvalidFormat_ThrowsFormatException_Test_TestCases))]
+        public void ToString_InvalidFormat_ThrowsFormatException_Test(string invalidFormat)
+        {
+            // Arrange
+            var duid = new Duid(new byte[] { 0xAB, 0xCD, 0xEF });
+
+            // Act
+            // Assert
+            Assert.Throws<FormatException>(() => duid.ToString(invalidFormat, null));
         }
 
         #endregion

--- a/src/NetDuid.Tests/Duid.IParsableTests.cs
+++ b/src/NetDuid.Tests/Duid.IParsableTests.cs
@@ -71,11 +71,24 @@ namespace NetDuid.Tests
             AddTestCase(string.Empty);
             AddTestCase("potato");
 
+            // whitespace-only strings — IsNullOrEmpty returns false, Trim() produces "", no regex match
+            AddTestCase("   ");
+            AddTestCase("\t");
+
             // invalid lengths
             foreach (var byteLength in new[] { 1, 2, 131, 200 })
             {
                 AddTestCase(StaticTestData.GenerateBytes(byteLength).BytesAsString());
             }
+
+            // mixed delimiters — delimited regex backreference \k<separator> requires a consistent delimiter
+            AddTestCase("AB:CD-EF");
+            AddTestCase("AB-CD:EF");
+
+            // structural problems
+            AddTestCase(":AB:CD:EF");
+            AddTestCase("AB:CD:EF:");
+            AddTestCase("AB::CD:EF");
 
             return theoryData;
 

--- a/src/NetDuid.Tests/Duid.ISerializableTests.cs
+++ b/src/NetDuid.Tests/Duid.ISerializableTests.cs
@@ -1,5 +1,8 @@
 ﻿#if !NET9_0_OR_GREATER
+using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
 
@@ -48,6 +51,98 @@ namespace NetDuid.Tests
                 Assert.NotNull(result);
                 Assert.Equal(duid, result);
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializable_Test_TestCases))]
+        public void Serializable_GetHashCode_Test(Duid duid)
+        {
+            // Arrange
+            using (var stream = new MemoryStream())
+            {
+#if !NET48
+#pragma warning disable SYSLIB0011
+#endif
+                var formatter = new BinaryFormatter();
+
+                // Act
+                formatter.Serialize(stream, duid);
+                stream.Seek(0, SeekOrigin.Begin);
+                var result = formatter.Deserialize(stream) as Duid;
+#if !NET48
+#pragma warning restore SYSLIB0011
+#endif
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(duid.GetHashCode(), result.GetHashCode());
+            }
+        }
+
+        #endregion
+
+        #region Deserialization exception paths
+
+        [Fact]
+        public void Deserialize_UnrecognizedVersion_ThrowsSerializationException_Test()
+        {
+            // Arrange
+#if !NET48
+#pragma warning disable SYSLIB0050
+#endif
+            var info = new SerializationInfo(typeof(Duid), new FormatterConverter());
+            info.AddValue("SerializableVersion", 999);
+            info.AddValue("_duidBytes", new byte[] { 0xAB, 0xCD, 0xEF }, typeof(byte[]));
+            var context = new StreamingContext(StreamingContextStates.All);
+#if !NET48
+#pragma warning restore SYSLIB0050
+#endif
+            var ctor = typeof(Duid).GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(SerializationInfo), typeof(StreamingContext) },
+                null
+            );
+
+            // Act
+            var exception = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { info, context }));
+
+            // Assert
+            Assert.IsType<SerializationException>(exception.InnerException);
+            Assert.Contains(
+                "Could not deserialize unrecognized format",
+                exception.InnerException.Message,
+                StringComparison.Ordinal
+            );
+        }
+
+        [Fact]
+        public void Deserialize_NullByteArray_ThrowsSerializationException_Test()
+        {
+            // Arrange
+#if !NET48
+#pragma warning disable SYSLIB0050
+#endif
+            var info = new SerializationInfo(typeof(Duid), new FormatterConverter());
+            info.AddValue("SerializableVersion", 0);
+            info.AddValue("_duidBytes", null, typeof(byte[]));
+            var context = new StreamingContext(StreamingContextStates.All);
+#if !NET48
+#pragma warning restore SYSLIB0050
+#endif
+            var ctor = typeof(Duid).GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(SerializationInfo), typeof(StreamingContext) },
+                null
+            );
+
+            // Act
+            var exception = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { info, context }));
+
+            // Assert
+            Assert.IsType<SerializationException>(exception.InnerException);
+            Assert.Contains("unrecognized input byte array", exception.InnerException.Message, StringComparison.Ordinal);
         }
 
         #endregion

--- a/src/NetDuid.Tests/Duid.OperatorsTests.cs
+++ b/src/NetDuid.Tests/Duid.OperatorsTests.cs
@@ -38,6 +38,38 @@ namespace NetDuid.Tests
 
         #endregion
 
+        #region Null Equality
+
+        [Fact]
+        public void Equality_Operator_BothNull_ReturnsTrue_Test()
+        {
+            // Arrange
+            Duid lhs = null;
+            Duid rhs = null;
+
+            // Act
+            var result = lhs == rhs;
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Inequality_Operator_BothNull_ReturnsFalse_Test()
+        {
+            // Arrange
+            Duid lhs = null;
+            Duid rhs = null;
+
+            // Act
+            var result = lhs != rhs;
+
+            // Assert
+            Assert.False(result);
+        }
+
+        #endregion
+
         #region Comparison Operators
 
         public static TheoryData<int, Duid, Duid> Operators_Duid_Test_TestCases()

--- a/src/NetDuid.Tests/DuidTests.cs
+++ b/src/NetDuid.Tests/DuidTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NetDuid;
 using NetDuid.Tests.XunitSerializers;
@@ -186,6 +187,64 @@ namespace NetDuid.Tests
 
             // Assert
             Assert.Equal(expectedString, result);
+        }
+
+        #endregion
+
+        #region GetBytes
+
+        public static TheoryData<byte[]> GetBytes_Test_TestCases()
+        {
+            var theoryData = new TheoryData<byte[]>();
+
+            for (var byteCount = 3; byteCount <= 130; byteCount += 5)
+            {
+                theoryData.Add(StaticTestData.GenerateBytes(byteCount, byteCount));
+            }
+
+            return theoryData;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetBytes_Test_TestCases))]
+        public void GetBytes_ReturnsIReadOnlyCollection_Test(byte[] inputBytes)
+        {
+            // Arrange
+            var duid = new Duid(inputBytes);
+
+            // Act
+            var result = duid.GetBytes();
+
+            // Assert
+            Assert.IsAssignableFrom<IReadOnlyCollection<byte>>(result);
+            Assert.Equal(inputBytes.Length, result.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetBytes_Test_TestCases))]
+        public void GetBytes_ReturnsCorrectBytes_Test(byte[] inputBytes)
+        {
+            // Arrange
+            var duid = new Duid(inputBytes);
+
+            // Act
+            var result = duid.GetBytes();
+
+            // Assert
+            Assert.Equal(inputBytes, result);
+        }
+
+        [Fact]
+        public void GetBytes_ReturnsReadOnlyView_Test()
+        {
+            // Arrange
+            var duid = new Duid(new byte[] { 0x00, 0x01, 0x02 });
+
+            // Act
+            var result = duid.GetBytes();
+
+            // Assert
+            Assert.IsNotType<byte[]>(result);
         }
 
         #endregion

--- a/src/NetDuid/Duid.Factory.cs
+++ b/src/NetDuid/Duid.Factory.cs
@@ -25,16 +25,28 @@ namespace NetDuid
         /// </remarks>
         public static bool TryParse(string duidString, out Duid duid)
         {
-            try
+            duid = null;
+
+            if (string.IsNullOrEmpty(duidString))
             {
-                duid = Parse(duidString);
-                return true;
-            }
-            catch
-            {
-                duid = null;
                 return false;
             }
+
+            var trimmed = duidString.Trim();
+
+            if (DuidRegexSource.GetDelimitedOctetsRegex().IsMatch(trimmed))
+            {
+                duid = new Duid(DelimitedStringToBytes(trimmed, 1));
+                return true;
+            }
+
+            if (DuidRegexSource.GetUndelimitedOctetsRegex().IsMatch(trimmed))
+            {
+                duid = new Duid(UndelimitedStringToBytes(trimmed));
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/NetDuid/Duid.IComparable.cs
+++ b/src/NetDuid/Duid.IComparable.cs
@@ -20,7 +20,7 @@ namespace NetDuid
 
             if (other is null)
             {
-                return -1;
+                return 1;
             }
 
             var thisLength = _duidBytes.Length;
@@ -60,7 +60,7 @@ namespace NetDuid
 
             if (obj is null)
             {
-                return -1;
+                return 1;
             }
 
             if (obj is Duid duid)

--- a/src/NetDuid/Duid.ISerializable.cs
+++ b/src/NetDuid/Duid.ISerializable.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace NetDuid
 {
@@ -23,6 +24,7 @@ namespace NetDuid
                     ?? throw new SerializationException("unrecognized input byte array");
                 _duidBytes = ConstructWithBytesGuard(bytes);
                 Type = GetDuidType();
+                _lazyHashCode = new Lazy<int>(ComputeHashCode);
                 return;
             }
 

--- a/src/NetDuid/Duid.cs
+++ b/src/NetDuid/Duid.cs
@@ -135,7 +135,7 @@ namespace NetDuid
         /// <returns>a collection of big-endian bytes</returns>
         public IReadOnlyCollection<byte> GetBytes()
         {
-            return _duidBytes;
+            return Array.AsReadOnly(_duidBytes);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fix IComparable null contract, GetBytes immutability, TryParse control flow, and serialization hash code

- CompareTo(Duid) and CompareTo(object) now return 1 when other is null,
  correctly satisfying the IComparable contract (non-null instance > null)
- GetBytes() wraps internal byte array in Array.AsReadOnly() to prevent
  external mutation of encapsulated state
- TryParse refactored away from exception-driven control flow; now checks
  for null/empty and trims whitespace before regex matching
- ISerializable deserialization constructor initializes _lazyHashCode,
  preventing an uninitialized Lazy<int> after round-trip deserialization
- Adds tests for whitespace edge cases (surrounding/only), mixed delimiters,
  invalid format strings, null operator overloads, GetBytes read-only
  contract, and serialization exception paths
